### PR TITLE
Update readme with default branch instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,3 +11,17 @@ support@kochava.com
 
 ### License
 KochavaTracker is available under the [Kochava Terms of Service](https://www.kochava.com/terms-of-service/).
+
+
+## Default Branch
+
+As of October 1, 2020, github.com uses the branch name ‘main’ when creating the initial default branch for all new repositories.  In order to minimize any customizations in our github usage and to support consistent naming conventions, we have made the decision to rename the ‘master’ branch to be called ‘main’ in all Kochava’s github repos.
+
+For local copies of the repo, the following steps will update to the new default branch:
+
+```
+git branch -m master main
+git fetch origin
+git branch -u origin/main main
+git remote set-head origin -a
+```


### PR DESCRIPTION
Adding instructions to the readme for local repo use after the default branch is renamed to 'main'.